### PR TITLE
pledge_menu(rewards)

### DIFF
--- a/ks-watch-and-manage.py
+++ b/ks-watch-and-manage.py
@@ -370,15 +370,9 @@ while True:
 
             if use_credentials:
                 pledge_manage.change_pledge(id, args.pledge_multiple, args.fixed_addition)
-                #import subprocess
-                #subprocess.call(["blink1-tool.exe", "--green"])
-                #subprocess.call(["twt.exe", "#repledged"])
                 print 'Re-pledged!!!'
             else :
                 if args.no_browser:
-                    #import subprocess
-                    #subprocess.call(["blink1-tool.exe", "--green"])
-                    #subprocess.call(["twt.exe", "#repledged"])
                     print 'Alert!!! Monitored pledge is unlocked: ', s[4]
                 else:
                     webbrowser.open_new_tab(url)

--- a/ks-watch-and-manage.py
+++ b/ks-watch-and-manage.py
@@ -25,7 +25,6 @@
 # the possibility of such damage.
 
 import sys
-import codecs
 import os
 import time
 import urllib
@@ -37,7 +36,10 @@ import webbrowser
 import argparse
 import pprint
 import logging
+import getpass
+import codecs
 
+#logging.basicConfig(level=logging.DEBUG)
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("main")
 sys.stdout = codecs.getwriter('utf8')(sys.stdout)
@@ -60,22 +62,25 @@ class KickstarterHTMLParser(HTMLParser.HTMLParser):
         HTMLParser.HTMLParser.__init__(self)
         self.in_form_block = False    # True == we're inside an <form class='...'> block
         self.in_script_block = False # True == we're inside a <script> block
-        self.url = url + '/new'
+        self.in_login_block = False # True == we're inside the login form div
+        self.must_enter_password = False
+        self.url = url
         self.logger = logging.getLogger("parser")
 
-    def process(self) :
+    def process(self, page = 'new') :
         while True:
             try:
-            	self.logger.debug('Opening URL- ' + self.url)
-                f = urllib2.urlopen(self.url)
+                url = self.url + '/' + page
+                self.logger.debug('Opening URL- ' + url)
+                f = urllib2.urlopen(url)
                 break
             except urllib2.HTTPError as e:
-            	self.logger.error('HTTP Error', exc_info=True)
+                self.logger.error('HTTP Error', exc_info=True)
             except urllib2.URLError as e:
-            	self.logger.error('URL Error', exc_info=True)
+                self.logger.error('URL Error', exc_info=True)
                 print 'URL Error', e
             except Exception as e:
-            	self.logger.error('Error', exc_info=True)
+                self.logger.error('Error', exc_info=True)
 
             self.logger.info('Due to error, retrying in 1 minute')
             time.sleep(60)
@@ -91,6 +96,9 @@ class KickstarterHTMLParser(HTMLParser.HTMLParser):
 
         self.logger.debug('Parsing fetched content')
         self.feed(html)   # feed() starts the HTMLParser parsing
+        text_file = open("http_reponse.html", "w")
+        text_file.write(html.encode('utf-8'))
+        text_file.close()
         self.logger.debug('Completed parsing content')
 
         # if the json variable current_project was loaded, then
@@ -127,6 +135,13 @@ class KickstarterHTMLParser(HTMLParser.HTMLParser):
 
         if tag == 'script' and len(attrs) == 0:
             self.in_script_block = True
+            return
+
+        if tag == 'div' and 'id' in attrs and attrs['id'] == 'login-signup':
+            self.in_form_block = True
+            self.must_enter_password = True
+            self.logger.debug("Must enter password")
+            return
 
         # TODO instead of this, just read the meta tags
         # and disengage the parsing when the body tag is reached
@@ -134,14 +149,19 @@ class KickstarterHTMLParser(HTMLParser.HTMLParser):
         # It turns out that we only care about tags that have a 'class' attribute
         if not 'class' in attrs:
             return
+
         if tag == 'form' and attrs['class'] == 'manage_pledge':
             self.in_form_block = True
+            return
+
         if self.in_form_block and tag == 'input' and attrs['class'] == 'hidden':
             self.form_hidden_inputs[attrs['name']] = attrs['value']
+            return
 
     def handle_endtag(self, tag):
         if tag == 'form':
             self.in_form_block = False
+            self.in_login_block = False
 
         if tag == 'script':
             self.in_script_block = False
@@ -193,34 +213,67 @@ class KickstarterHTMLParser(HTMLParser.HTMLParser):
         return self.rewards
 
 class KickstarterPledgeManage:
-    def __init__(self, cookies_file, parser, url):
-        self.cookie_jar = cookielib.MozillaCookieJar(cookies_file)
-        self.cookie_jar.load()
-        self.cookie_opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(self.cookie_jar))
+    def __init__(self, cookies_file, parser, url, login = None, password = None):
+        self.logger = logging.getLogger("manage")
+        if cookies_file:
+            self.logger.debug('Using the cookie file')
+            self.cookie_jar = cookielib.MozillaCookieJar(cookies_file)
+            self.cookie_jar.load()
+        else:
+            self.logger.debug('Using an empty cookie jar')
+            self.cookie_jar = cookielib.CookieJar()
+        # self.cookie_opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(self.cookie_jar))
+        self.cookie_opener = urllib2.build_opener(
+            urllib2.HTTPRedirectHandler(),
+            urllib2.HTTPHandler(debuglevel=0),
+            urllib2.HTTPSHandler(debuglevel=0),
+            urllib2.HTTPCookieProcessor(self.cookie_jar)
+        )
         self.parser = parser
         self.proxy_handler = urllib2.ProxyHandler({})
         self.blank_opener = urllib2.build_opener(self.proxy_handler)
-        self.logger = logging.getLogger("manage")
         self.url = url
+        self.password = password
+        self.login = login
 
     def run_test(self):
-    	self.logger.debug('Starting cookie test')
+        self.logger.debug('Starting cookie test')
         self.engage_cookie() # use the cookies
         self.parser.process() # fetch the page
         result = self.parser.logged_in
-    	self.logger.debug('Completed cookie test')
+        self.logger.debug('Completed cookie test')
         self.disengage_cookie()
 
         # pprint.pprint(self.parser.json_variables, indent = 2)
         return result
 
     def change_pledge(self, id, multiply_ = 1, add_ = 0):
-    	self.logger.debug('Changing pledge')
+        self.logger.debug('Changing pledge')
         self.engage_cookie() # use the cookies
-        rewards = self.parser.process() # fetch the page
+        rewards = self.parser.process('edit') # fetch the page
 
-    	self.logger.info('Creating re-pledge request')
         submit_data = self.parser.form_hidden_inputs
+        pprint.pprint(self.parser)
+
+        if self.parser.must_enter_password:
+            submit_data['user_session[password]'] = self.password
+            submit_data['user_session[email]'] = self.login
+            submit_data['utf8'] = '' # urllib.encode doesn't support encoding of utf8 characters
+            pprint.pprint(submit_data)
+            pprint.pprint(self.login)
+            pprint.pprint(self.password)
+            data = urllib.urlencode(submit_data)
+            f = urllib2.urlopen(url='https://www.kickstarter.com/user_sessions', data=data)
+            html = unicode(f.read(), 'utf-8')
+            f.close()
+            text_file = open("login_reponse.html", "w")
+            text_file.write(html.encode('utf-8'))
+            text_file.close()
+            rewards = self.parser.process('edit')
+            self.cookie_jar.save()
+
+
+        self.logger.info('Creating re-pledge request')
         
         submit_data['utf8'] = '' # urllib.encode doesn't support encoding of utf8 characters
         submit_data['backing[amount]'] = s[0] * multiply_
@@ -241,6 +294,9 @@ class KickstarterPledgeManage:
 
     def disengage_cookie(self):
         urllib2.install_opener(self.blank_opener)
+
+    def engage_login_opener(self):
+        urllib2.install_opener(self.login_opener)
 
 
 def pledge_menu(rewards):
@@ -283,6 +339,10 @@ parser.add_argument("-c", "--cookies", type=file,
     metavar="COOKIES-FILE",
     help="path to the cookies file used to manage the pledge" +
     " (only the Netscape format is accepted)")
+parser.add_argument("-l", "--login", type=str,
+    help="login into Kickstarter using the account username and password")
+parser.add_argument("-pwd", "--password", type=str,
+    help="login into Kickstarter using the account username and password")
 # parser.add_argument("-d", "--destroy", action="store_true",
 #     help="destroy (/cancel) pledge if the required pledge(s) couldn't be" +
 #     " selected (requires cookies)")
@@ -313,7 +373,8 @@ pledges = None   # The pledge amounts on the command line
 ids = None       # A list of IDs of the pledge levels
 selected = None  # A list of selected pledge levels
 rewards = None   # A list of valid reward levels
-use_credentials = False
+use_cookies = False
+use_login = False
 
 stats = None   # A list of the initial statuses of the selected pledge level
 priority = None
@@ -323,7 +384,7 @@ ks = KickstarterHTMLParser(url)
 
 if args.cookies:
     # need to test the credentials
-    use_credentials = True
+    use_cookies = True
     logger.info('Testing supplied credentials (cookies)')
     pledge_manage = KickstarterPledgeManage(args.cookies.name, ks, url)
     if not pledge_manage.run_test():
@@ -331,6 +392,19 @@ if args.cookies:
         sys.exit(0)
     else:
         logger.info('Successfully logged into Kickstarter using cookies')
+
+if args.login:
+    use_cookies = True
+    password = getpass.getpass('Enter account password :') if not args.password else args.password
+    login = args.login
+    logger.info('Testing supplied credentials (username)')
+    logger.info(login)
+    logger.info(password)
+    if not args.cookies:
+        pledge_manage = KickstarterPledgeManage(None, ks, url, login=login, password=password)
+    else:
+        pledge_manage = KickstarterPledgeManage(args.cookies.name, ks, url, login=login, password=password)
+
 
 if args.pledge_amount:
     logger.debug('Pledges are given in amount')
@@ -348,15 +422,15 @@ while True:
         sys.exit(0)
 
     #if ids:
-        #selected = [r for r in rewards if r[3] in ids]
+            #selected = [r for r in rewards if r[3] in ids]
+    #else:
+    if pledges:
+        selected = [r for r in rewards if r[0] in pledges]
+        pledges = None
     else:
-        if pledges:
-            selected = [r for r in rewards if r[0] in pledges]
-            pledges = None
-        else:
-            # If a pledge amount was not specified on the command-line, then prompt
-            # the user with a menu
-            selected = pledge_menu(rewards)
+        # If a pledge amount was not specified on the command-line, then prompt
+        # the user with a menu
+        selected = pledge_menu(rewards)
 
         # pprint.pprint(selected)
         ids = [s[3] for s in selected]
@@ -368,17 +442,17 @@ while True:
 
         if s[1] > 0 or s[2] == 'Unlimited' and current_priority < pledge_priority_reached:
 
-            if use_credentials:
+            if use_cookies:
                 pledge_manage.change_pledge(id, args.pledge_multiple, args.fixed_addition)
-                #import subprocess
-                #subprocess.call(["blink1-tool.exe", "--green"])
-                #subprocess.call(["twt.exe", "#repledged"])
+                import subprocess
+                subprocess.call(["blink1-tool.exe", "--green"])
+                subprocess.call(["twt.exe", "#repledged"])
                 print 'Re-pledged!!!'
             else :
                 if args.no_browser:
-                    #import subprocess
-                    #subprocess.call(["blink1-tool.exe", "--green"])
-                    #subprocess.call(["twt.exe", "#repledged"])
+                    import subprocess
+                    subprocess.call(["blink1-tool.exe", "--green"])
+                    subprocess.call(["twt.exe", "#repledged"])
                     print 'Alert!!! Monitored pledge is unlocked: ', s[4]
                 else:
                     webbrowser.open_new_tab(url)

--- a/ks-watch-and-manage.py
+++ b/ks-watch-and-manage.py
@@ -256,14 +256,12 @@ def pledge_menu(rewards):
 
             if args.pledge:
                 numbers = args.pledge
-
             else:
                 for i in xrange(count):
                     print '%u. $%u %s' % (i + 1, rewards[i][0], rewards[i][4][:70])
                     print '\t\t %s' % (rewards[i][2])
                 ans = raw_input('\nSelect pledge levels: ')
                 numbers = map(int, ans.split())
-                
             return [rewards[i - 1] for i in numbers]
         except (IndexError, NameError, SyntaxError):
             continue
@@ -334,7 +332,6 @@ if args.cookies:
         sys.exit(0)
     else:
         logger.info('Successfully logged into Kickstarter using cookies')
-
 if args.pledge_amount:
     logger.debug('Pledges are given in amount')
     pledges = args.pledge
@@ -352,7 +349,6 @@ while True:
 
 	if ids:
 	    selected = [r for r in rewards if r[3] in ids]
-		
     else:
         if pledges:
             selected = [r for r in rewards if r[0] in pledges]
@@ -368,7 +364,7 @@ while True:
         priority = range(0,len(ids))
         pledge_priority_reached = len(ids) + 1
 
-     for stat, s, id, current_priority in zip(stats, selected, ids, priority):
+    for stat, s, id, current_priority in zip(stats, selected, ids, priority):
 
         if s[1] > 0 or s[2] == 'Unlimited' and current_priority < pledge_priority_reached:
 

--- a/ks-watch-and-manage.py
+++ b/ks-watch-and-manage.py
@@ -347,7 +347,7 @@ while True:
         sys.exit(0)
 
     if ids:
-    	selected = [r for r in rewards if r[3] in ids]
+        selected = [r for r in rewards if r[3] in ids]
     else:
         if pledges:
             selected = [r for r in rewards if r[0] in pledges]

--- a/ks-watch-and-manage.py
+++ b/ks-watch-and-manage.py
@@ -268,7 +268,6 @@ def pledge_menu(rewards):
         except (IndexError, NameError, SyntaxError):
             continue
 
-
 parser = argparse.ArgumentParser(
     description="This script notifies you by opening the manage pledge page" +
     " in the browser when a locked Kickstarter  pledge level becomes available" +
@@ -368,22 +367,22 @@ while True:
         stats = [s[1] for s in selected]
         priority = range(0,len(ids))
         pledge_priority_reached = len(ids) + 1
-	
-    for stat, s, id, current_priority in zip(stats, selected, ids, priority):
+
+     for stat, s, id, current_priority in zip(stats, selected, ids, priority):
 
         if s[1] > 0 or s[2] == 'Unlimited' and current_priority < pledge_priority_reached:
 
             if use_credentials:
                 pledge_manage.change_pledge(id, args.pledge_multiple, args.fixed_addition)
-                import subprocess
-                subprocess.call(["blink1-tool.exe", "--green"])
-                subprocess.call(["twt.exe", "#repledged"])
+                #import subprocess
+                #subprocess.call(["blink1-tool.exe", "--green"])
+                #subprocess.call(["twt.exe", "#repledged"])
                 print 'Re-pledged!!!'
             else :
                 if args.no_browser:
-                    import subprocess
-                    subprocess.call(["blink1-tool.exe", "--green"])
-                    subprocess.call(["twt.exe", "#repledged"])
+                    #import subprocess
+                    #subprocess.call(["blink1-tool.exe", "--green"])
+                    #subprocess.call(["twt.exe", "#repledged"])
                     print 'Alert!!! Monitored pledge is unlocked: ', s[4]
                 else:
                     webbrowser.open_new_tab(url)

--- a/ks-watch-and-manage.py
+++ b/ks-watch-and-manage.py
@@ -25,6 +25,7 @@
 # the possibility of such damage.
 
 import sys
+import codecs
 import os
 import time
 import urllib
@@ -36,10 +37,7 @@ import webbrowser
 import argparse
 import pprint
 import logging
-import getpass
-import codecs
 
-#logging.basicConfig(level=logging.DEBUG)
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("main")
 sys.stdout = codecs.getwriter('utf8')(sys.stdout)
@@ -62,25 +60,22 @@ class KickstarterHTMLParser(HTMLParser.HTMLParser):
         HTMLParser.HTMLParser.__init__(self)
         self.in_form_block = False    # True == we're inside an <form class='...'> block
         self.in_script_block = False # True == we're inside a <script> block
-        self.in_login_block = False # True == we're inside the login form div
-        self.must_enter_password = False
-        self.url = url
+        self.url = url + '/new'
         self.logger = logging.getLogger("parser")
 
-    def process(self, page = 'new') :
+    def process(self) :
         while True:
             try:
-                url = self.url + '/' + page
-                self.logger.debug('Opening URL- ' + url)
-                f = urllib2.urlopen(url)
+            	self.logger.debug('Opening URL- ' + self.url)
+                f = urllib2.urlopen(self.url)
                 break
             except urllib2.HTTPError as e:
-                self.logger.error('HTTP Error', exc_info=True)
+            	self.logger.error('HTTP Error', exc_info=True)
             except urllib2.URLError as e:
-                self.logger.error('URL Error', exc_info=True)
+            	self.logger.error('URL Error', exc_info=True)
                 print 'URL Error', e
             except Exception as e:
-                self.logger.error('Error', exc_info=True)
+            	self.logger.error('Error', exc_info=True)
 
             self.logger.info('Due to error, retrying in 1 minute')
             time.sleep(60)
@@ -96,9 +91,6 @@ class KickstarterHTMLParser(HTMLParser.HTMLParser):
 
         self.logger.debug('Parsing fetched content')
         self.feed(html)   # feed() starts the HTMLParser parsing
-        text_file = open("http_reponse.html", "w")
-        text_file.write(html.encode('utf-8'))
-        text_file.close()
         self.logger.debug('Completed parsing content')
 
         # if the json variable current_project was loaded, then
@@ -135,13 +127,6 @@ class KickstarterHTMLParser(HTMLParser.HTMLParser):
 
         if tag == 'script' and len(attrs) == 0:
             self.in_script_block = True
-            return
-
-        if tag == 'div' and 'id' in attrs and attrs['id'] == 'login-signup':
-            self.in_form_block = True
-            self.must_enter_password = True
-            self.logger.debug("Must enter password")
-            return
 
         # TODO instead of this, just read the meta tags
         # and disengage the parsing when the body tag is reached
@@ -149,19 +134,14 @@ class KickstarterHTMLParser(HTMLParser.HTMLParser):
         # It turns out that we only care about tags that have a 'class' attribute
         if not 'class' in attrs:
             return
-
         if tag == 'form' and attrs['class'] == 'manage_pledge':
             self.in_form_block = True
-            return
-
         if self.in_form_block and tag == 'input' and attrs['class'] == 'hidden':
             self.form_hidden_inputs[attrs['name']] = attrs['value']
-            return
 
     def handle_endtag(self, tag):
         if tag == 'form':
             self.in_form_block = False
-            self.in_login_block = False
 
         if tag == 'script':
             self.in_script_block = False
@@ -213,67 +193,34 @@ class KickstarterHTMLParser(HTMLParser.HTMLParser):
         return self.rewards
 
 class KickstarterPledgeManage:
-    def __init__(self, cookies_file, parser, url, login = None, password = None):
-        self.logger = logging.getLogger("manage")
-        if cookies_file:
-            self.logger.debug('Using the cookie file')
-            self.cookie_jar = cookielib.MozillaCookieJar(cookies_file)
-            self.cookie_jar.load()
-        else:
-            self.logger.debug('Using an empty cookie jar')
-            self.cookie_jar = cookielib.CookieJar()
-        # self.cookie_opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(self.cookie_jar))
-        self.cookie_opener = urllib2.build_opener(
-            urllib2.HTTPRedirectHandler(),
-            urllib2.HTTPHandler(debuglevel=0),
-            urllib2.HTTPSHandler(debuglevel=0),
-            urllib2.HTTPCookieProcessor(self.cookie_jar)
-        )
+    def __init__(self, cookies_file, parser, url):
+        self.cookie_jar = cookielib.MozillaCookieJar(cookies_file)
+        self.cookie_jar.load()
+        self.cookie_opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(self.cookie_jar))
         self.parser = parser
         self.proxy_handler = urllib2.ProxyHandler({})
         self.blank_opener = urllib2.build_opener(self.proxy_handler)
+        self.logger = logging.getLogger("manage")
         self.url = url
-        self.password = password
-        self.login = login
 
     def run_test(self):
-        self.logger.debug('Starting cookie test')
+    	self.logger.debug('Starting cookie test')
         self.engage_cookie() # use the cookies
         self.parser.process() # fetch the page
         result = self.parser.logged_in
-        self.logger.debug('Completed cookie test')
+    	self.logger.debug('Completed cookie test')
         self.disengage_cookie()
 
         # pprint.pprint(self.parser.json_variables, indent = 2)
         return result
 
     def change_pledge(self, id, multiply_ = 1, add_ = 0):
-        self.logger.debug('Changing pledge')
+    	self.logger.debug('Changing pledge')
         self.engage_cookie() # use the cookies
-        rewards = self.parser.process('edit') # fetch the page
+        rewards = self.parser.process() # fetch the page
 
+    	self.logger.info('Creating re-pledge request')
         submit_data = self.parser.form_hidden_inputs
-        pprint.pprint(self.parser)
-
-        if self.parser.must_enter_password:
-            submit_data['user_session[password]'] = self.password
-            submit_data['user_session[email]'] = self.login
-            submit_data['utf8'] = '' # urllib.encode doesn't support encoding of utf8 characters
-            pprint.pprint(submit_data)
-            pprint.pprint(self.login)
-            pprint.pprint(self.password)
-            data = urllib.urlencode(submit_data)
-            f = urllib2.urlopen(url='https://www.kickstarter.com/user_sessions', data=data)
-            html = unicode(f.read(), 'utf-8')
-            f.close()
-            text_file = open("login_reponse.html", "w")
-            text_file.write(html.encode('utf-8'))
-            text_file.close()
-            rewards = self.parser.process('edit')
-            self.cookie_jar.save()
-
-
-        self.logger.info('Creating re-pledge request')
         
         submit_data['utf8'] = '' # urllib.encode doesn't support encoding of utf8 characters
         submit_data['backing[amount]'] = s[0] * multiply_
@@ -294,9 +241,6 @@ class KickstarterPledgeManage:
 
     def disengage_cookie(self):
         urllib2.install_opener(self.blank_opener)
-
-    def engage_login_opener(self):
-        urllib2.install_opener(self.login_opener)
 
 
 def pledge_menu(rewards):
@@ -339,10 +283,6 @@ parser.add_argument("-c", "--cookies", type=file,
     metavar="COOKIES-FILE",
     help="path to the cookies file used to manage the pledge" +
     " (only the Netscape format is accepted)")
-parser.add_argument("-l", "--login", type=str,
-    help="login into Kickstarter using the account username and password")
-parser.add_argument("-pwd", "--password", type=str,
-    help="login into Kickstarter using the account username and password")
 # parser.add_argument("-d", "--destroy", action="store_true",
 #     help="destroy (/cancel) pledge if the required pledge(s) couldn't be" +
 #     " selected (requires cookies)")
@@ -373,8 +313,7 @@ pledges = None   # The pledge amounts on the command line
 ids = None       # A list of IDs of the pledge levels
 selected = None  # A list of selected pledge levels
 rewards = None   # A list of valid reward levels
-use_cookies = False
-use_login = False
+use_credentials = False
 
 stats = None   # A list of the initial statuses of the selected pledge level
 priority = None
@@ -384,7 +323,7 @@ ks = KickstarterHTMLParser(url)
 
 if args.cookies:
     # need to test the credentials
-    use_cookies = True
+    use_credentials = True
     logger.info('Testing supplied credentials (cookies)')
     pledge_manage = KickstarterPledgeManage(args.cookies.name, ks, url)
     if not pledge_manage.run_test():
@@ -392,19 +331,6 @@ if args.cookies:
         sys.exit(0)
     else:
         logger.info('Successfully logged into Kickstarter using cookies')
-
-if args.login:
-    use_cookies = True
-    password = getpass.getpass('Enter account password :') if not args.password else args.password
-    login = args.login
-    logger.info('Testing supplied credentials (username)')
-    logger.info(login)
-    logger.info(password)
-    if not args.cookies:
-        pledge_manage = KickstarterPledgeManage(None, ks, url, login=login, password=password)
-    else:
-        pledge_manage = KickstarterPledgeManage(args.cookies.name, ks, url, login=login, password=password)
-
 
 if args.pledge_amount:
     logger.debug('Pledges are given in amount')
@@ -442,17 +368,17 @@ while True:
 
         if s[1] > 0 or s[2] == 'Unlimited' and current_priority < pledge_priority_reached:
 
-            if use_cookies:
+            if use_credentials:
                 pledge_manage.change_pledge(id, args.pledge_multiple, args.fixed_addition)
-                import subprocess
-                subprocess.call(["blink1-tool.exe", "--green"])
-                subprocess.call(["twt.exe", "#repledged"])
+                #import subprocess
+                #subprocess.call(["blink1-tool.exe", "--green"])
+                #subprocess.call(["twt.exe", "#repledged"])
                 print 'Re-pledged!!!'
             else :
                 if args.no_browser:
-                    import subprocess
-                    subprocess.call(["blink1-tool.exe", "--green"])
-                    subprocess.call(["twt.exe", "#repledged"])
+                    #import subprocess
+                    #subprocess.call(["blink1-tool.exe", "--green"])
+                    #subprocess.call(["twt.exe", "#repledged"])
                     print 'Alert!!! Monitored pledge is unlocked: ', s[4]
                 else:
                     webbrowser.open_new_tab(url)

--- a/ks-watch-and-manage.py
+++ b/ks-watch-and-manage.py
@@ -363,7 +363,7 @@ while True:
         stats = [s[1] for s in selected]
         priority = range(0,len(ids))
         pledge_priority_reached = len(ids) + 1
-	
+
     for stat, s, id, current_priority in zip(stats, selected, ids, priority):
 
         if s[1] > 0 or s[2] == 'Unlimited' and current_priority < pledge_priority_reached:

--- a/ks-watch-and-manage.py
+++ b/ks-watch-and-manage.py
@@ -253,7 +253,6 @@ def pledge_menu(rewards):
 
     while True:
         try:
-
             if args.pledge:
                 numbers = args.pledge
             else:
@@ -347,8 +346,8 @@ while True:
         logger.info('No limited rewards for this Kickstarter')
         sys.exit(0)
 
-	if ids:
-	    selected = [r for r in rewards if r[3] in ids]
+    if ids:
+    	selected = [r for r in rewards if r[3] in ids]
     else:
         if pledges:
             selected = [r for r in rewards if r[0] in pledges]

--- a/ks-watch-and-manage.py
+++ b/ks-watch-and-manage.py
@@ -375,15 +375,15 @@ while True:
 
             if use_credentials:
                 pledge_manage.change_pledge(id, args.pledge_multiple, args.fixed_addition)
-                import subprocess
-                subprocess.call(["blink1-tool.exe", "--green"])
-                subprocess.call(["twt.exe", "#repledged"])
+                #import subprocess
+                #subprocess.call(["blink1-tool.exe", "--green"])
+                #subprocess.call(["twt.exe", "#repledged"])
                 print 'Re-pledged!!!'
             else :
                 if args.no_browser:
-                    import subprocess
-                    subprocess.call(["blink1-tool.exe", "--green"])
-                    subprocess.call(["twt.exe", "#repledged"])
+                    #import subprocess
+                    #subprocess.call(["blink1-tool.exe", "--green"])
+                    #subprocess.call(["twt.exe", "#repledged"])
                     print 'Alert!!! Monitored pledge is unlocked: ', s[4]
                 else:
                     webbrowser.open_new_tab(url)

--- a/ks-watch-and-manage.py
+++ b/ks-watch-and-manage.py
@@ -347,8 +347,8 @@ while True:
         logger.info('No limited rewards for this Kickstarter')
         sys.exit(0)
 
-	if ids:
-	    selected = [r for r in rewards if r[3] in ids]
+    #if ids:
+        #selected = [r for r in rewards if r[3] in ids]
     else:
         if pledges:
             selected = [r for r in rewards if r[0] in pledges]

--- a/ks-watch-and-manage.py
+++ b/ks-watch-and-manage.py
@@ -331,7 +331,7 @@ if args.cookies:
         sys.exit(0)
     else:
         logger.info('Successfully logged into Kickstarter using cookies')
-        
+
 if args.pledge_amount:
     logger.debug('Pledges are given in amount')
     pledges = args.pledge

--- a/ks-watch-and-manage.py
+++ b/ks-watch-and-manage.py
@@ -251,7 +251,6 @@ def pledge_menu(rewards):
     if count == 1:
         return rewards[0]
 
-    #import pdb; pdb.set_trace()
     while True:
         try:
 

--- a/ks-watch-and-manage.py
+++ b/ks-watch-and-manage.py
@@ -363,7 +363,7 @@ while True:
         stats = [s[1] for s in selected]
         priority = range(0,len(ids))
         pledge_priority_reached = len(ids) + 1
-
+	
     for stat, s, id, current_priority in zip(stats, selected, ids, priority):
 
         if s[1] > 0 or s[2] == 'Unlimited' and current_priority < pledge_priority_reached:

--- a/ks-watch-and-manage.py
+++ b/ks-watch-and-manage.py
@@ -253,21 +253,17 @@ def pledge_menu(rewards):
 
     while True:
         try:
-
             if args.pledge:
                 numbers = args.pledge
-
             else:
                 for i in xrange(count):
                     print '%u. $%u %s' % (i + 1, rewards[i][0], rewards[i][4][:70])
                     print '\t\t %s' % (rewards[i][2])
                 ans = raw_input('\nSelect pledge levels: ')
                 numbers = map(int, ans.split())
-                
             return [rewards[i - 1] for i in numbers]
         except (IndexError, NameError, SyntaxError):
             continue
-
 
 parser = argparse.ArgumentParser(
     description="This script notifies you by opening the manage pledge page" +
@@ -353,7 +349,6 @@ while True:
 
 	if ids:
 	    selected = [r for r in rewards if r[3] in ids]
-		
     else:
         if pledges:
             selected = [r for r in rewards if r[0] in pledges]

--- a/ks-watch-and-manage.py
+++ b/ks-watch-and-manage.py
@@ -251,19 +251,24 @@ def pledge_menu(rewards):
     if count == 1:
         return rewards[0]
 
+    #import pdb; pdb.set_trace()
     while True:
         try:
+
             if args.pledge:
                 numbers = args.pledge
+
             else:
                 for i in xrange(count):
                     print '%u. $%u %s' % (i + 1, rewards[i][0], rewards[i][4][:70])
                     print '\t\t %s' % (rewards[i][2])
                 ans = raw_input('\nSelect pledge levels: ')
                 numbers = map(int, ans.split())
+                
             return [rewards[i - 1] for i in numbers]
         except (IndexError, NameError, SyntaxError):
             continue
+
 
 parser = argparse.ArgumentParser(
     description="This script notifies you by opening the manage pledge page" +
@@ -347,8 +352,9 @@ while True:
         logger.info('No limited rewards for this Kickstarter')
         sys.exit(0)
 
-    if ids:
-        selected = [r for r in rewards if r[3] in ids]
+	if ids:
+	    selected = [r for r in rewards if r[3] in ids]
+		
     else:
         if pledges:
             selected = [r for r in rewards if r[0] in pledges]
@@ -370,15 +376,15 @@ while True:
 
             if use_credentials:
                 pledge_manage.change_pledge(id, args.pledge_multiple, args.fixed_addition)
-                #import subprocess
-                #subprocess.call(["blink1-tool.exe", "--green"])
-                #subprocess.call(["twt.exe", "#repledged"])
+                import subprocess
+                subprocess.call(["blink1-tool.exe", "--green"])
+                subprocess.call(["twt.exe", "#repledged"])
                 print 'Re-pledged!!!'
             else :
                 if args.no_browser:
-                    #import subprocess
-                    #subprocess.call(["blink1-tool.exe", "--green"])
-                    #subprocess.call(["twt.exe", "#repledged"])
+                    import subprocess
+                    subprocess.call(["blink1-tool.exe", "--green"])
+                    subprocess.call(["twt.exe", "#repledged"])
                     print 'Alert!!! Monitored pledge is unlocked: ', s[4]
                 else:
                     webbrowser.open_new_tab(url)

--- a/ks-watch-and-manage.py
+++ b/ks-watch-and-manage.py
@@ -331,6 +331,7 @@ if args.cookies:
         sys.exit(0)
     else:
         logger.info('Successfully logged into Kickstarter using cookies')
+        
 if args.pledge_amount:
     logger.debug('Pledges are given in amount')
     pledges = args.pledge


### PR DESCRIPTION
So I have put logic into pledge_menu(rewards)
This will allow you to use --pledge with only ONE argument, or more if you want. previously, I could not get --pledge to work with only one argument.

However, I needed to comment out a few lines to get this to work, or else I get errors 

The lines I needed to comment out were 350-352
# if ids:

```
        #selected = [r for r in rewards if r[3] in ids]
#else:
```

Traceback (most recent call last):
  File "C:\Startup\ks-watch-and-manage.py", line 367, in <module>
    for stat, s, id, current_priority in zip(stats, selected, ids, priority):
TypeError: zip argument #1 must support iteration
